### PR TITLE
fix: browser-compatible dynamic import for optional miniscript

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@kukks/bitcoin-descriptors",
   "description": "This library parses and creates Bitcoin Miniscript Descriptors and generates Partially Signed Bitcoin Transactions (PSBTs). It provides PSBT finalizers and signers for single-signature, BIP32 and Hardware Wallets.",
   "homepage": "https://github.com/Kukks/descriptors",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,10 @@ export type { Network } from './networks.js';
 // Built-in adapters using @noble/curves and @scure/bip32
 export { nobleECPair, scureBIP32 } from './adapters.js';
 
+// Optional miniscript support — call before using miniscript descriptors
+// if you need to guarantee the library is loaded synchronously.
+export { ensureMiniscriptLoaded } from './miniscript.js';
+
 // Pre-built factory using built-in adapters (zero-config convenience)
 import { DescriptorsFactory } from './descriptors.js';
 export const defaultFactory = DescriptorsFactory();

--- a/src/miniscript.ts
+++ b/src/miniscript.ts
@@ -10,11 +10,16 @@ import type { BIP32API } from './types.js';
 import { parseKeyExpression } from './keyExpressions.js';
 import * as RE from './re.js';
 import type { PartialSig } from './types.js';
-import { createRequire } from 'module';
-
 // Lazy-load @bitcoinerlab/miniscript (optional peer dependency).
+// Uses dynamic import() so it works in both Node and browser bundlers (Vite/Rollup).
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let _miniscriptLib: any;
+// Kick off loading immediately but don't block — the result is awaited on first use.
+const _miniscriptPromise = import('@bitcoinerlab/miniscript').then(
+  m => (_miniscriptLib = m),
+  () => {} // not installed — will error at use time
+);
+
 function getMiniscriptLib(): {
   compileMiniscript: (ms: string) => { issane: boolean; asm: string };
   satisfier: (
@@ -29,17 +34,20 @@ function getMiniscriptLib(): {
   };
 } {
   if (!_miniscriptLib) {
-    try {
-      const require = createRequire(import.meta.url);
-      _miniscriptLib = require('@bitcoinerlab/miniscript');
-    } catch {
-      throw new Error(
-        '@bitcoinerlab/miniscript is required for miniscript descriptors. ' +
-          'Install it: npm install @bitcoinerlab/miniscript'
-      );
-    }
+    throw new Error(
+      '@bitcoinerlab/miniscript is required for miniscript descriptors. ' +
+        'Install it: npm install @bitcoinerlab/miniscript'
+    );
   }
   return _miniscriptLib;
+}
+
+/**
+ * Ensure the optional miniscript library has finished loading.
+ * Call before using any miniscript code path.
+ */
+export async function ensureMiniscriptLoaded(): Promise<void> {
+  await _miniscriptPromise;
 }
 import type { Preimage, TimeConstraints, ExpansionMap } from './types.js';
 

--- a/test/optionalMiniscript.test.ts
+++ b/test/optionalMiniscript.test.ts
@@ -1,0 +1,47 @@
+// Test that @bitcoinerlab/miniscript is an optional dependency.
+// Non-miniscript descriptors must work regardless; miniscript descriptors
+// require the peer dependency to be installed.
+
+import { DescriptorsFactory, ensureMiniscriptLoaded } from '../dist/index.js';
+
+const { Output } = DescriptorsFactory();
+
+describe('Optional @bitcoinerlab/miniscript dependency', () => {
+  test('non-miniscript descriptors work without miniscript lib', () => {
+    // wpkh — should never touch miniscript code path
+    const wpkh = new Output({
+      descriptor:
+        'wpkh(02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9)'
+    });
+    expect(wpkh.getAddress()).toBeDefined();
+
+    // pkh
+    const pkh = new Output({
+      descriptor:
+        'pkh(02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9)'
+    });
+    expect(pkh.getAddress()).toBeDefined();
+
+    // tr (taproot single key)
+    const tr = new Output({
+      descriptor:
+        'tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)'
+    });
+    expect(tr.getAddress()).toBeDefined();
+  });
+
+  test('ensureMiniscriptLoaded resolves when lib is installed', async () => {
+    // The lib IS installed as a devDependency, so this should resolve.
+    await expect(ensureMiniscriptLoaded()).resolves.toBeUndefined();
+  });
+
+  test('miniscript descriptors work after lib is loaded', async () => {
+    await ensureMiniscriptLoaded();
+    // wsh(miniscript) descriptor — exercises the miniscript code path
+    const output = new Output({
+      descriptor:
+        'wsh(and_v(v:pk(02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5),pk(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)))'
+    });
+    expect(output.getAddress()).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Replace `createRequire` from `module` (Node-only) with dynamic `import()` for the optional `@bitcoinerlab/miniscript` peer dependency
- Fixes Vite/Rollup browser builds that broke with `3.2.1`/`3.2.2` — `createRequire` is not available in browser environments
- Adds `ensureMiniscriptLoaded()` export for consumers who need to guarantee the lib is loaded before sync calls
- Adds test coverage for optional miniscript dependency behavior
- Bumps to `3.2.3`

## Context
The `3.2.1` release introduced `createRequire` from `module` to lazily load `@bitcoinerlab/miniscript`. This works in Node but Vite externalizes the `module` built-in for browser targets, causing build failures:
```
"createRequire" is not exported by "__vite-browser-external"
```

## Test plan
- [x] Existing unit tests pass (same results as before — no regressions)
- [x] New `optionalMiniscript.test.ts` verifies non-miniscript descriptors work, `ensureMiniscriptLoaded()` resolves, and miniscript descriptors work after loading
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ensureMiniscriptLoaded()` async function to explicitly initialize miniscript library support when needed.

* **Tests**
  * Added test suite validating optional miniscript dependency handling, confirming standard descriptors work independently and miniscript-dependent features function correctly after initialization.

* **Chores**
  * Patch version bump to 3.2.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->